### PR TITLE
Reuse fitted scaler in DSExplainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ model = RandomForestRegressor(n_estimators=100, random_state=42)
 
 max_comb = 3
 explainer = DSExplainer(model, comb=max_comb,X=X_train,Y=y_train)
+# The fitted MinMaxScaler is stored in the explainer and reused for new data
 model = explainer.getModel()
 mass_values_df, certainty_df, plausibility_df = explainer.ds_values(X_test[:2])
  


### PR DESCRIPTION
## Summary
- persist the scaler inside `DSExplainer`
- reuse the stored scaler for new data in `ds_values`
- allow `generate_combinations` to accept a scaler
- document scaler reuse in README

## Testing
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_686d31fac6548331b1f2e7926a8cf255