### PR TITLE
Add LLM summary to Titanic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ from DSExplainer import DSExplainer
 
 ### Example Usage
 
-The example below demonstrates how to use `DSExplainer` with the Titanic dataset to train a `RandomForestRegressor` and analyze its predictions:
+The example below demonstrates how to use `DSExplainer` with the Titanic dataset to train a `RandomForestRegressor` and analyze its predictions. The script also shows how to send a summary of each prediction to an LLM using the `ollama` package for natural language interpretation:
 
 ```python
 import pandas as pd

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 statsmodels
 scikit-learn
 shap
+ollama

--- a/titanic.py
+++ b/titanic.py
@@ -5,6 +5,8 @@ from sklearn.model_selection import train_test_split
 from DSExplainer import DSExplainer
 
 from sklearn.datasets import fetch_openml
+import ollama
+from textwrap import dedent
 titanic = fetch_openml('titanic', version=1, as_frame=True)
 data = titanic.frame
 data = data.drop(columns=['boat', 'body', 'home.dest'])
@@ -26,7 +28,9 @@ for col in categorical_columns:
 X = features
 y = target
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.1, random_state=42
+)
 model = RandomForestRegressor(n_estimators=100, random_state=42)
     
 
@@ -51,3 +55,52 @@ def print_top_columns(df, df_name):
 print_top_columns(mass_values_df, "mass_values_df")
 print_top_columns(certainty_df, "certainty_df")
 print_top_columns(plausibility_df, "plausibility_df")
+
+# ----- LLM Interpretation -----
+DATASET_DESCRIPTION = dedent(
+    """
+    The Titanic dataset contains information about passengers on the famous ship.
+    Each row represents a passenger and includes variables such as ticket class
+    (`pclass`), sex, age, number of siblings/spouses (`sibsp`) and parents/
+    children (`parch`) aboard, the fare paid, cabin, and embarkation port. The
+    target variable is `survived`, indicating whether the passenger lived.
+    """
+)
+
+FEATURES_TEXT = ", ".join(X.columns)
+
+
+def resumen_fila(row_idx: int) -> str:
+    X_row = explainer.generate_combinations(X_test.iloc[[row_idx]])
+    pred = model.predict(X_row)[0]
+    mass_top = mass_values_df.iloc[row_idx].nlargest(top_n)
+    cert_top = certainty_df.iloc[row_idx].nlargest(top_n)
+    plaus_top = plausibility_df.iloc[row_idx].nlargest(top_n)
+
+    resumen = [
+        f"Prediction for row {row_idx}: {pred}",
+        "Top combinations by mass: "
+        + ", ".join(f"{k} ({v:.3f})" for k, v in mass_top.items()),
+        "Highest certainty in: "
+        + ", ".join(f"{k} ({v:.3f})" for k, v in cert_top.items()),
+        "Greatest plausibility in: "
+        + ", ".join(f"{k} ({v:.3f})" for k, v in plaus_top.items()),
+    ]
+
+    return "\n".join(resumen)
+
+
+for idx in range(len(mass_values_df)):
+    prompt = (
+        DATASET_DESCRIPTION
+        + f"\nColumns: {FEATURES_TEXT}\n"
+        + resumen_fila(idx)
+        + "\nProvide an English interpretation of this inference result."
+    )
+
+    try:
+        response = ollama.chat(model="llama2", messages=[{"role": "user", "content": prompt}])
+        print(f"\nLLM interpretation for row {idx}:")
+        print(response.message.content)
+    except Exception as e:
+        print(f"\nCould not obtain LLM interpretation for row {idx}: {e}")


### PR DESCRIPTION
## Summary
- modify Titanic example to request an LLM interpretation via ollama
- include new explanation text in English
- mention ollama usage in the README

## Testing
- `python -m py_compile titanic.py`
- `python titanic.py` *(fails to connect to Ollama)*

------
https://chatgpt.com/codex/tasks/task_e_686d3fbfa258833182fe9e4391f64de2