### PR TITLE
Include certainty and plausibility in LLM prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ from DSExplainer import DSExplainer
 
 ### Example Usage
 
-The example below demonstrates how to use `DSExplainer` with the Titanic dataset to train a `RandomForestRegressor` and analyze its predictions:
+The example below demonstrates how to use `DSExplainer` with the Titanic dataset to train a `RandomForestRegressor` and analyze its predictions. The script also shows how to send a summary of each prediction—including certainty and plausibility metrics—to an LLM using the `ollama` package for natural language interpretation. Each DSExplainer dataframe is augmented with the predicted survival label so the LLM can explain why the passenger survived or not, based on a provided dataset description and objective.
+
+By default the script queries the `mannix/jan-nano` model. If your Ollama server
+is running on a different machine, set the `OLLAMA_HOST` environment variable to
+the server's address, for example `OLLAMA_HOST="http://1.2.3.4:11434"`.
 
 ```python
 import pandas as pd

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 statsmodels
 scikit-learn
 shap
+ollama

--- a/titanic.py
+++ b/titanic.py
@@ -5,6 +5,10 @@ from sklearn.model_selection import train_test_split
 from DSExplainer import DSExplainer
 
 from sklearn.datasets import fetch_openml
+import ollama
+import os
+from textwrap import dedent
+import re
 titanic = fetch_openml('titanic', version=1, as_frame=True)
 data = titanic.frame
 data = data.drop(columns=['boat', 'body', 'home.dest'])
@@ -26,14 +30,28 @@ for col in categorical_columns:
 X = features
 y = target
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.1, random_state=42
+)
 model = RandomForestRegressor(n_estimators=100, random_state=42)
+
+
+OLLAMA_HOST = os.getenv("OLLAMA_HOST")
+llm_client = ollama.Client(host=OLLAMA_HOST) if OLLAMA_HOST else ollama
     
 
 max_comb = 3
 explainer = DSExplainer(model, comb=max_comb,X=X_train,Y=y_train)
 model = explainer.getModel()
-mass_values_df, certainty_df, plausibility_df = explainer.ds_values(X_test[:2])
+subset = X_test[:2]
+mass_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
+
+# Generate predictions for the same rows and append them to each result DataFrame
+X_pred = explainer.generate_combinations(subset)
+raw_preds = model.predict(X_pred)
+pred_labels = ["survived" if p >= 0.5 else "did not survive" for p in raw_preds]
+for df in (mass_values_df, certainty_df, plausibility_df):
+    df["prediction"] = pred_labels
  
 
 
@@ -42,7 +60,9 @@ top_n = 3
 
 def print_top_columns(df, df_name):
     for idx, row in df.iterrows():
-        top_values = row.nlargest(top_n)
+        numeric_row = row.drop(labels=["prediction"], errors="ignore")
+        numeric_row = pd.to_numeric(numeric_row, errors="coerce")
+        top_values = numeric_row.nlargest(top_n)
         print(f"\n{df_name}, Fila {idx}:")
         for col, val in top_values.items():
             print(f"    {col}: {val}")
@@ -51,3 +71,58 @@ def print_top_columns(df, df_name):
 print_top_columns(mass_values_df, "mass_values_df")
 print_top_columns(certainty_df, "certainty_df")
 print_top_columns(plausibility_df, "plausibility_df")
+
+# ----- LLM Interpretation -----
+DATASET_DESCRIPTION = dedent(
+    """
+    The Titanic dataset contains information about passengers on the famous ship.
+    Each row represents a passenger and includes variables such as ticket class
+    (`pclass`), sex, age, number of siblings/spouses (`sibsp`) and parents/
+    children (`parch`) aboard, the fare paid, cabin, and embarkation port. The
+    target variable is `survived`, indicating whether the passenger lived.
+    """
+)
+
+OBJECTIVE_DESCRIPTION = "Explain why the passenger survived or not based on the DSExplainer metrics."
+
+FEATURES_TEXT = ", ".join(X.columns)
+
+
+def resumen_fila(row_idx: int) -> str:
+    pred = mass_values_df.loc[row_idx, "prediction"]
+
+    mass_vals = ", ".join(
+        f"{k}: {v:.3f}" for k, v in mass_values_df.drop(columns="prediction").iloc[row_idx].items()
+    )
+    cert_vals = ", ".join(
+        f"{k}: {v:.3f}" for k, v in certainty_df.drop(columns="prediction").iloc[row_idx].items()
+    )
+    plaus_vals = ", ".join(
+        f"{k}: {v:.3f}" for k, v in plausibility_df.drop(columns="prediction").iloc[row_idx].items()
+    )
+
+    resumen = [
+        f"Prediction for row {row_idx}: {pred}",
+        f"Mass values: {mass_vals}",
+        f"Certainty values: {cert_vals}",
+        f"Plausibility values: {plaus_vals}",
+    ]
+
+    return "\n".join(resumen)
+
+
+for idx in range(len(mass_values_df)):
+    prompt = (
+        DATASET_DESCRIPTION
+        + f"\nObjective: {OBJECTIVE_DESCRIPTION}"
+        + f"\nColumns: {FEATURES_TEXT}\n"
+        + resumen_fila(idx)
+    )
+
+    try:
+        response = llm_client.chat(model="mannix/jan-nano", messages=[{"role": "user", "content": prompt}])
+        clean = re.sub(r"<think>.*?</think>", "", response.message.content, flags=re.DOTALL).strip()
+        print(f"\nLLM interpretation for row {idx}:")
+        print(clean)
+    except Exception as e:
+        print(f"\nCould not obtain LLM interpretation for row {idx}: {e}")


### PR DESCRIPTION
## Summary
- mention certainty and plausibility metrics in README LLM description
- allow remote Ollama server via `OLLAMA_HOST` and use `mannix/jan-nano` model
- send certainty and plausibility row values to Ollama in Titanic example
- add passenger survival prediction column and objective text for LLM explanation
- sanitize LLM response by removing `<think>` tags
- fix numeric column sorting by converting Series to numeric

## Testing
- `python -m py_compile titanic.py DSExplainer.py iris_example.py`
- `python titanic.py` *(fails to connect to Ollama)*

------
https://chatgpt.com/codex/tasks/task_e_686d3fbfa258833182fe9e4391f64de2