### PR TITLE
Add reusable scaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ max_comb = 3
 explainer = DSExplainer(model, comb=max_comb,X=X_train,Y=y_train)
 # The fitted MinMaxScaler is stored in the explainer and reused for new data
 model = explainer.getModel()
-train_preds = model.predict(explainer.generate_combinations(X_train))
+train_preds = model.predict(
+    explainer.generate_combinations(X_train, scaler=explainer.scaler)
+)
 model_error = mean_absolute_error(y_train, train_preds) / (y_train.max() - y_train.min())
 mass_values_df, certainty_df, plausibility_df = explainer.ds_values(X_test[:2], error_rate=model_error)
  

--- a/iris_example.py
+++ b/iris_example.py
@@ -43,8 +43,8 @@ orig_subset = original_features.loc[subset.index]
 
 mass_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
 
-# Generate predictions for the selected rows
-X_pred = explainer.generate_combinations(subset)
+# Generate predictions for the selected rows using the fitted scaler
+X_pred = explainer.generate_combinations(subset, scaler=explainer.scaler)
 raw_preds = model.predict(X_pred)
 pred_labels = [target_names[int(round(p))] for p in raw_preds]
 

--- a/titanic.py
+++ b/titanic.py
@@ -52,8 +52,8 @@ subset = X.sample(n=1, random_state=np.random.randint(0, 10000))
 orig_subset = original_features.loc[subset.index]
 mass_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
 
-# Generate predictions for the selected rows
-X_pred = explainer.generate_combinations(subset)
+# Generate predictions for the selected rows using the stored scaler
+X_pred = explainer.generate_combinations(subset, scaler=explainer.scaler)
 raw_preds = model.predict(X_pred)
 pred_labels = ["survived" if p >= 0.5 else "did not survive" for p in raw_preds]
 

--- a/titanic_comparison.py
+++ b/titanic_comparison.py
@@ -52,7 +52,8 @@ orig_subset = original_features.loc[subset.index]
 
 shap_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
 
-X_pred = explainer.generate_combinations(subset)
+# Use the stored scaler for prediction features
+X_pred = explainer.generate_combinations(subset, scaler=explainer.scaler)
 raw_preds = model.predict(X_pred)
 pred_labels = ["survived" if p >= 0.5 else "did not survive" for p in raw_preds]
 for df in (shap_values_df, certainty_df, plausibility_df):


### PR DESCRIPTION
## Summary
- create and fit a MinMaxScaler in `DSExplainer.__init__`
- reuse the stored scaler in `generate_combinations`
- mention scaler handling in the docs
- pass the scaler when predicting in examples and README

## Testing
- `python -m py_compile DSExplainer.py`

------
https://chatgpt.com/codex/tasks/task_e_686dc7b1cef083319617afb09ec7e3c8