### PR TITLE
Return mass values from ds_values

### DIFF
--- a/DSExplainer.py
+++ b/DSExplainer.py
@@ -130,8 +130,10 @@ class DSExplainer:
         Returns
         -------
         tuple of pandas.DataFrame
-            ``shap_values_df`` with raw SHAP values, ``certainty_df`` and
-            ``plausibility_df`` containing Dempster–Shafer metrics.
+            ``shap_values_df`` with raw SHAP values, ``mass_values_df`` with the
+            normalized masses (including an ``"uncertainty"`` column),
+            ``certainty_df`` and ``plausibility_df`` containing Dempster–Shafer
+            metrics.
         """
         X = self.generate_combinations(X, scaler=self.scaler)
 
@@ -154,6 +156,8 @@ class DSExplainer:
 
         normalized_shap = normalized_shap.mul(1 - error_rate, axis=0)
         normalized_shap["uncertainty"] = error_rate
+
+        mass_values_df = normalized_shap.copy()
 
         results = []
 
@@ -194,4 +198,4 @@ class DSExplainer:
             {**{'Index': res['Index']}, **res['Plausibility']} for res in results
         ]).set_index('Index')
 
-        return shap_values_df, certainty_df, plausibility_df
+        return shap_values_df, mass_values_df, certainty_df, plausibility_df

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ train_preds = model.predict(
     explainer.generate_combinations(X_train, scaler=explainer.scaler)
 )
 model_error = mean_absolute_error(y_train, train_preds) / (y_train.max() - y_train.min())
-mass_values_df, certainty_df, plausibility_df = explainer.ds_values(X_test[:2], error_rate=model_error)
+shap_values_df, mass_values_df, certainty_df, plausibility_df = explainer.ds_values(
+    X_test[:2], error_rate=model_error
+)
  
 
 
@@ -102,7 +104,9 @@ print_top_columns(plausibility_df, "plausibility_df")
 ### Methods
 
 - `ds_values(X, error_rate=0.0)`: Generates SHAP values, certainty, and plausibility metrics for the input dataset `X`. The optional `error_rate` parameter represents the model's percent error (between 0 and 1) and is treated as the Dempster\u2013Shafer uncertainty mass.
-  - **Returns**: Three pandas DataFrames: `shap_values_df`, `certainty_df`, and `plausibility_df`.
+  - **Returns**: Four pandas DataFrames: `shap_values_df`,
+    `mass_values_df` (normalized masses with an `"uncertainty"` column),
+    `certainty_df`, and `plausibility_df`.
 
 ## Theory Behind DSExplainer
 

--- a/iris_example.py
+++ b/iris_example.py
@@ -41,7 +41,9 @@ np.random.seed(int(time.time()) % 2**32)
 subset = X_scaled.sample(n=1, random_state=np.random.randint(0, 10000))
 orig_subset = original_features.loc[subset.index]
 
-mass_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
+shap_values_df, mass_values_df, certainty_df, plausibility_df = explainer.ds_values(
+    subset
+)
 
 # Generate predictions for the selected rows using the fitted scaler
 X_pred = explainer.generate_combinations(subset, scaler=explainer.scaler)

--- a/titanic.py
+++ b/titanic.py
@@ -50,7 +50,9 @@ model = explainer.getModel()
 np.random.seed(int(time.time()) % 2**32)  # Cambia semilla en cada ejecución
 subset = X.sample(n=1, random_state=np.random.randint(0, 10000))
 orig_subset = original_features.loc[subset.index]
-mass_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
+shap_values_df, mass_values_df, certainty_df, plausibility_df = explainer.ds_values(
+    subset
+)
 
 # Generate predictions for the selected rows using the stored scaler
 X_pred = explainer.generate_combinations(subset, scaler=explainer.scaler)

--- a/titanic_comparison.py
+++ b/titanic_comparison.py
@@ -50,7 +50,7 @@ np.random.seed(int(time.time()) % 2**32)
 subset = X.sample(n=20, random_state=np.random.randint(0, 100000))
 orig_subset = original_features.loc[subset.index]
 
-shap_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
+shap_values_df, mass_values_df, certainty_df, plausibility_df = explainer.ds_values(subset)
 
 # Use the stored scaler for prediction features
 X_pred = explainer.generate_combinations(subset, scaler=explainer.scaler)


### PR DESCRIPTION
## Summary
- add normalized mass output in `ds_values`
- document new output in README
- adapt Titanic, Iris and comparison examples for updated return value

## Testing
- `python -m py_compile DSExplainer.py titanic.py iris_example.py titanic_comparison.py`

------
https://chatgpt.com/codex/tasks/task_e_686dd58a13388331b5cf2f4667ed7e31