### PR TITLE
Fix feature combination generation

### DIFF
--- a/DSExplainer.py
+++ b/DSExplainer.py
@@ -87,11 +87,11 @@ class DSExplainer:
 
         # Generate combinations of columns and add their sums to the dataset
         for r in range(2, self.comb + 1):
-           new_columns = [
-              (pd.Series(X[list(cols)].sum(axis=1), name="_x_".join(cols)))
-                  for cols in combinations(X.columns, r)]
-
-        new_dataset = pd.concat([new_dataset] + new_columns, axis=1)
+            new_columns = [
+                pd.Series(X[list(cols)].sum(axis=1), name="_x_".join(cols))
+                for cols in combinations(X.columns, r)
+            ]
+            new_dataset = pd.concat([new_dataset] + new_columns, axis=1)
                 
         # Use the provided scaler or fall back to the stored one
         scaler = scaler or self.scaler

--- a/tests/test_generate_combinations.py
+++ b/tests/test_generate_combinations.py
@@ -1,0 +1,25 @@
+import unittest
+import pandas as pd
+from sklearn.preprocessing import MinMaxScaler
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from DSExplainer import DSExplainer
+
+class GenerateCombinationsTest(unittest.TestCase):
+    def test_pairs_and_triplets_created(self):
+        X = pd.DataFrame({
+            'A': [1, 2],
+            'B': [3, 4],
+            'C': [5, 6]
+        })
+        explainer = object.__new__(DSExplainer)
+        explainer.comb = 3
+        explainer.scaler = MinMaxScaler()
+        result = DSExplainer.generate_combinations(explainer, X, scaler=explainer.scaler)
+        expected = ['A_x_B', 'A_x_C', 'B_x_C', 'A_x_B_x_C']
+        for col in expected:
+            self.assertIn(col, result.columns)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix feature combination generation so all pairwise and higher order columns are kept
- add unit test for `generate_combinations`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de0d9896c83319a3abec07fa66d50