### PR TITLE
Polish English wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ top_n = 3
 def print_top_columns(df, df_name):
     for idx, row in df.iterrows():
         top_values = row.nlargest(top_n)
-        print(f"\n{df_name}, Fila {idx}:")
+        print(f"\n{df_name}, Row {idx}:")
         for col, val in top_values.items():
             print(f"    {col}: {val}")
 

--- a/ds_explainer_paper.tex
+++ b/ds_explainer_paper.tex
@@ -18,7 +18,7 @@
 \acmNumber{4}
 \acmArticle{111}
 \acmMonth{8}
-\usepackage{float} % Coloca esto en el preámbulo
+\usepackage{float} % Place this in the preamble
 
 \title{DSExplainer: Increasing interpretability in complex scenarios through Certainty and Plausibility Metrics}
 

--- a/iris_example.py
+++ b/iris_example.py
@@ -16,7 +16,7 @@ llm_client = ollama.Client(host=OLLAMA_HOST) if OLLAMA_HOST else ollama
 
 # Language used to translate the LLM output. Can be overridden with the
 # TRANSLATION_LANGUAGE environment variable.
-TRANSLATION_LANGUAGE = os.getenv("TRANSLATION_LANGUAGE", "español")
+TRANSLATION_LANGUAGE = os.getenv("TRANSLATION_LANGUAGE", "Spanish")
 
 # Load Iris dataset as pandas DataFrame
 iris = load_iris(as_frame=True)

--- a/titanic.py
+++ b/titanic.py
@@ -41,7 +41,7 @@ llm_client = ollama.Client(host=OLLAMA_HOST) if OLLAMA_HOST else ollama
 
 # Language used to translate the LLM output. Can be overridden with the
 # TRANSLATION_LANGUAGE environment variable.
-TRANSLATION_LANGUAGE = os.getenv("TRANSLATION_LANGUAGE", "español")
+TRANSLATION_LANGUAGE = os.getenv("TRANSLATION_LANGUAGE", "Spanish")
 
     
 
@@ -56,7 +56,7 @@ train_preds = model.predict(train_features)
 target_range = y_numeric.max() - y_numeric.min()
 model_error = mean_absolute_error(y_numeric, train_preds) / target_range
 print(f"Model error rate: {model_error:.4f}")
-np.random.seed(int(time.time()) % 2**32)  # Cambia semilla en cada ejecución
+np.random.seed(int(time.time()) % 2**32)  # Change seed for every run
 subset = X.sample(n=1, random_state=np.random.randint(0, 10000))
 orig_subset = original_features.loc[subset.index]
 
@@ -121,7 +121,7 @@ def print_top_columns(df, df_name):
         numeric_row = pd.to_numeric(numeric_row, errors="coerce")
 
         top_values = numeric_row.nlargest(top_n)
-        print(f"\n{df_name}, Fila {idx}:")
+        print(f"\n{df_name}, Row {idx}:")
         for col, val in top_values.items():
             print(f"    {col}: {val}")
 


### PR DESCRIPTION
## Summary
- translate Spanish comment in ds_explainer_paper.tex
- fix README example wording in English
- change translation setting defaults to "Spanish"
- clarify random seed comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769caaeda88331b210522604bf5998