### PR TITLE
Show prompts and LLM outputs

### DIFF
--- a/evaluate_breast_cancer.py
+++ b/evaluate_breast_cancer.py
@@ -6,6 +6,12 @@ from sklearn.metrics import mean_absolute_error
 from DSExplainer import DSExplainer
 import numpy as np
 from textwrap import dedent
+import ollama
+import os
+import re
+
+OLLAMA_HOST = os.getenv("OLLAMA_HOST")
+llm_client = ollama.Client(host=OLLAMA_HOST) if OLLAMA_HOST else ollama
 
 # Load dataset
 cancer = load_breast_cancer(as_frame=True)
@@ -78,3 +84,11 @@ print(comparison_df)
 
 for idx, prompt in demp_prompts.items():
     print(f"Prompt {idx}:\n{prompt}\n")
+    try:
+        resp = llm_client.chat(model="mannix/jan-nano", messages=[{"role": "user", "content": prompt}])
+        clean_resp = re.sub(r"<think>.*?</think>", "", resp.message.content, flags=re.DOTALL).strip()
+        print("--- LLM RESPONSE ---")
+        print(clean_resp)
+        print("--------------------\n")
+    except Exception as e:
+        print("LLM error:", e)

--- a/evaluate_titanic.py
+++ b/evaluate_titanic.py
@@ -86,11 +86,6 @@ OBJECTIVE_DEMPSTER = dedent("""
     error_rate=model_error,
 )
 
-# Remove raw prediction values from the prompts to avoid
-# conveying survival percentages directly.
-for idx, text in demp_prompts.items():
-    lines = [ln for ln in text.splitlines() if not ln.startswith("Prediction for row")]
-    demp_prompts[idx] = "\n".join(lines)
 
 pred_labels = ["survived" if p >= 0.5 else "did not survive" for p in shap_df["prediction"]]
 true_labels = ["survived" if t == 1 else "did not survive" for t in y.loc[subset.index]]


### PR DESCRIPTION
## Summary
- print the entire prompt when evaluating Titanic and Breast Cancer
- send Breast Cancer prompts to the LLM and display the answer

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ae48737ec8331985807d304929e97