### PR TITLE
Add missing label for methodology section

### DIFF
--- a/ds_explainer_paper.tex
+++ b/ds_explainer_paper.tex
@@ -233,6 +233,7 @@ Recent works emphasize calibration of explanation methods. Quantus benchmarks ex
 
 
 \section{Methodology (DSExplainer)}
+\label{sec:combining}
 The core innovation of DSExplainer is the fusion of two distinct yet complementary methodologies: SHAP values and Dempster-Shafer theory. This section details how we combine these approaches to create a comprehensive framework for model interpretability that not only provides feature attributions but also quantifies the uncertainty associated with them.
 \subsection{Notation}
 We denote by $X \in \mathbb{R}^{n \times p}$ the feature matrix and by $f$ the fitted model. Hypotheses formed by up to $k$ features are written as $x_{i_1} \cap \dots \cap x_{i_j}$.


### PR DESCRIPTION
## Summary
- add `sec:combining` label to fix reference to the DSExplainer methodology section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0b3eba988331b1ac156ec8812b8a