### PR TITLE
Add missing uncertainty citations

### DIFF
--- a/ds_explainer_paper.tex
+++ b/ds_explainer_paper.tex
@@ -228,7 +228,7 @@ The integration of Dempster-Shafer theory into our interpretability framework of
 
 Through these mechanisms, Dempster-Shafer theory enriches the interpretability process by introducing an uncertainty-aware perspective that complements the deterministic explanations provided by SHAP values. This dual analysis is critical in real-world applications, where understanding both the magnitude and the reliability of a model’s predictions is essential.
 \subsection{Uncertainty in XAI}
-Recent works emphasize calibration of explanation methods. Quantus benchmarks explanation robustness, while BayesSHAP provides Bayesian uncertainty estimates for SHAP values. Evidential deep learning similarly treats predictions as evidence. DSExplainer builds on these ideas by framing SHAP attributions within Dempster--Shafer metrics.
+Recent works emphasize calibration of explanation methods. Quantus benchmarks explanation robustness\cite{hedstrom2023quantus}, while BayesSHAP provides Bayesian uncertainty estimates for SHAP values\cite{slack2021reliable}. Evidential deep learning similarly treats predictions as evidence\cite{sensoy2018edl}. DSExplainer builds on these ideas by framing SHAP attributions within Dempster--Shafer metrics.
 
 
 


### PR DESCRIPTION
## Summary
- cite Quantus for explanation robustness benchmarking
- cite BayesSHAP for Bayesian SHAP uncertainty
- cite Evidential Deep Learning for evidence-based prediction uncertainty

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c18363bc883318daf7effd42583a0