### PR TITLE
Place LLM section before results

### DIFF
--- a/ds_explainer_paper.tex
+++ b/ds_explainer_paper.tex
@@ -399,6 +399,12 @@ Performance is measured with accuracy while calibration is assessed using the Br
 \subsection{Procedure}
 Experiments rely on fixed random seeds with 5-fold cross validation to ensure robust comparisons.
 
+\subsection{LLM-Assisted Interpretation}
+
+Numerical metrics can be difficult to convey to non-experts. To bridge this gap we experimented with a lightweight large language model (LLM) that receives the top certainty and plausibility hypotheses as a prompt and returns a concise narrative explaining each prediction. We use the open-source \texttt{mannix/jan-nano} model via the \texttt{ollama} interface, allowing DSExplainer to produce a short textual rationale that complements the quantitative tables.
+This explicit inclusion of certainty and plausibility metrics in the prompt is, to our knowledge, a novel way to provide the language model with a measure of reliability. In practice, the compact \texttt{jan-nano} model produces sensible explanations for most cases, but the text occasionally contains hallucinated details, so we recommend relying on higher-quality LLMs when available to reduce such errors.
+
+Across both datasets, the LLM focused on the same features highlighted by DSExplainer. In the Titanic case, it frequently discussed how \texttt{sex}, \texttt{age} and \texttt{fare} interacted to influence the survival outcome, echoing the model's low certainty but high plausibility when evidence conflicted. On the Iris samples, the LLM attributed each species prediction to characteristic petal measurements, mirroring the top certainty and plausibility triples. These summaries show that even a compact LLM can translate DSExplainer's numeric metrics into accessible language, enhancing the overall interpretability of individual predictions.
 \section{Results}
 \label{sec:results}
 \subsection{Interpretability Example}
@@ -831,12 +837,6 @@ The tumor is predicted to be benign. The high plausibility (77.07\%) of the feat
 
 \end{adjustwidth}
 
-\subsection{LLM-Assisted Interpretation}
-
-Numerical metrics can be difficult to convey to non-experts. To bridge this gap we experimented with a lightweight large language model (LLM) that receives the top certainty and plausibility hypotheses as a prompt and returns a concise narrative explaining each prediction. We use the open-source \texttt{mannix/jan-nano} model via the \texttt{ollama} interface, allowing DSExplainer to produce a short textual rationale that complements the quantitative tables.
-This explicit inclusion of certainty and plausibility metrics in the prompt is, to our knowledge, a novel way to provide the language model with a measure of reliability. In practice, the compact \texttt{jan-nano} model produces sensible explanations for most cases, but the text occasionally contains hallucinated details, so we recommend relying on higher-quality LLMs when available to reduce such errors.
-
-Across both datasets, the LLM focused on the same features highlighted by DSExplainer. In the Titanic case, it frequently discussed how \texttt{sex}, \texttt{age} and \texttt{fare} interacted to influence the survival outcome, echoing the model's low certainty but high plausibility when evidence conflicted. On the Iris samples, the LLM attributed each species prediction to characteristic petal measurements, mirroring the top certainty and plausibility triples. These summaries show that even a compact LLM can translate DSExplainer's numeric metrics into accessible language, enhancing the overall interpretability of individual predictions.
 
 
 \section{Discussion}


### PR DESCRIPTION
## Summary
- move the `LLM-Assisted Interpretation` subsection before the Results section in `ds_explainer_paper.tex`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c220a1d5083318138322994935242